### PR TITLE
fix: add permissions for commit-comment action

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,5 +1,11 @@
 name: Weekly Benchmarks
 
+permissions:
+  contents: read
+  packages: read
+  pull-requests: write
+  issues: write
+
 on:
   schedule:
     - cron: '0 2 * * 0'  # Every Sunday at 2am UTC


### PR DESCRIPTION
Weekly Benchmarks CI fails at the commit-comment step with 403 because the workflow lacks `issues: write` permission.

Added explicit `permissions` block to grant the commit-comment action the ability to post results.

The benchmark job itself succeeds (83.3% accuracy). Only the final comment step fails.